### PR TITLE
fix: add waf on production_env

### DIFF
--- a/cdk/service/api_construct.py
+++ b/cdk/service/api_construct.py
@@ -28,7 +28,7 @@ class ApiConstruct(Construct):
         self._build_swagger_endpoints(rest_api=self.rest_api, dest_func=self.create_order_func)
         self.monitoring = CrudMonitoring(self, id_, self.rest_api, self.api_db.db, self.api_db.idempotency_db, [self.create_order_func])
 
-        if not is_production_env:
+        if is_production_env:
             # add WAF
             self.waf = WafToApiGatewayConstruct(self, f'{id_}waf', self.rest_api)
 


### PR DESCRIPTION
WAF was disabled on production environments with https://github.com/ran-isenberg/aws-lambda-handler-cookbook/pull/895. I guess this was disabled by accident/for testing purpose as now WAF is getting added only on non production environments.